### PR TITLE
Fix GUI not loading

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN apt update \
     /var/tmp/*
 
 # Install WireGuard, OpenVPN and other dependencies for running the container scripts
-RUN echo "deb http://deb.debian.org/debian/ unstable main" > /etc/apt/sources.list.d/unstable-wireguard.list \ 
+RUN echo "deb http://deb.debian.org/debian/ unstable main" > /etc/apt/sources.list.d/unstable-wireguard.list \
     && printf 'Package: *\nPin: release a=unstable\nPin-Priority: 150\n' > /etc/apt/preferences.d/limit-unstable \
     && echo "deb http://deb.debian.org/debian/ bullseye non-free" > /etc/apt/sources.list.d/non-free-unrar.list \
     && printf 'Package: *\nPin: release a=non-free\nPin-Priority: 150\n' > /etc/apt/preferences.d/limit-non-free \

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,7 @@ RUN echo "deb http://deb.debian.org/debian/ unstable main" > /etc/apt/sources.li
     p7zip-full \
     par2 \
     procps \
+    python3-setuptools \
     unrar \
     unzip \
     wireguard-tools \


### PR DESCRIPTION
The new version of SABnzbd 3.5.1 (https://github.com/sabnzbd/sabnzbd/releases/tag/3.5.1) did require `python3-setuptools`, that is now included in this release.  
Closes #9 