### PR TITLE
Allow container to run wireguard without --privileged

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,6 +85,9 @@ RUN echo "deb http://deb.debian.org/debian/ unstable main" > /etc/apt/sources.li
     /tmp/* \
     /var/tmp/*
 
+# Remove src_valid_mark from wg-quick
+RUN sed -i /net\.ipv4\.conf\.all\.src_valid_mark/d `which wg-quick`
+
 VOLUME /config /downloads
 
 ADD openvpn/ /etc/openvpn/

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The container is available from the Docker registry and this is the simplest way
 To run the container use this command, with additional parameters, please refer to the Variables, Volumes, and Ports section:
 
 ```
-$ docker run --privileged  -d \
+$ docker run  -d \
               -v /your/config/path/:/config \
               -v /your/downloads/path/:/downloads \
               -e "VPN_ENABLED=yes" \
@@ -27,6 +27,8 @@ $ docker run --privileged  -d \
               -e "LAN_NETWORK=192.168.0.0/24" \
               -e "NAME_SERVERS=1.1.1.1,1.0.0.1" \
               -p 8080:8080 \
+              --cap-add NET_ADMIN \
+              --sysctl "net.ipv4.conf.all.src_valid_mark=1" \
               --restart unless-stopped \
               dyonr/sabnzbdvpn
 ```


### PR DESCRIPTION
Based on DyonR/docker-qbittorrentvpn#61, this allows the container to be run without the privileged flag.